### PR TITLE
Use load_cmd instead of struct load_command as a return type

### DIFF
--- a/cs_bypass.m
+++ b/cs_bypass.m
@@ -41,7 +41,7 @@ sect_cmd *find_section(sgmt_cmd *seg, const char *name)
     return fs;
 }
 
-struct load_command *find_load_command(mach_hdr *mh, uint32_t cmd)
+load_cmd *find_load_command(mach_hdr *mh, uint32_t cmd)
 {
     load_cmd *lc, *flc;
     lc = (load_cmd *)((uint64_t)mh + sizeof(mach_hdr));


### PR DESCRIPTION
Use the already defined `load_cmd` in replace of `struct load_command` for the `find_section` function.
